### PR TITLE
Add a break after autoremove is confirmed and run

### DIFF
--- a/zypptools
+++ b/zypptools
@@ -19,7 +19,7 @@ function autoremove() {
         while true; do
             read -p "Do you want to remove these  packages including their dependencies? [y/n] " yn
             case $yn in
-                [Yy]* ) sudo zypper remove --clean-deps $unneeded;;
+                [Yy]* ) sudo zypper remove --clean-deps $unneeded && break;;
                 [Nn]* ) exit;;
                 * ) echo "Please answer yes or no.";;
             esac


### PR DESCRIPTION
The autoremove function didn't stop after confirmation and subsequent run - instead it kept prompting with the confirmation message. The reason for this was the while loop, which should now be terminated by "break" after a successful run